### PR TITLE
Add support for WebSockets

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "typeix",
   "version": "1.0.0",
   "dependencies": {
-    "reflect-metadata": "^0.1.10"
+    "reflect-metadata": "^0.1.10",
+    "ws": "^3.2.0"
   },
   "description": "Typescript API for RESTful Services for (Node.js)",
   "main": "build/index.js",
@@ -41,6 +42,7 @@
     "@types/node": "^8.0.20",
     "@types/sinon": "^2.3.3",
     "@types/sinon-chai": "^2.7.28",
+    "@types/ws": "^3.2.0",
     "chai": "^4.1.1",
     "mocha": "^3.5.0",
     "sinon": "^2.4.1",

--- a/src/decorators/action.ts
+++ b/src/decorators/action.ts
@@ -137,3 +137,5 @@ export let Before = mapAction("Before");
  * Define name of after action to class
  */
 export let After = mapAction("After");
+
+export let Hook = mapAction("Hook");

--- a/src/decorators/action.ts
+++ b/src/decorators/action.ts
@@ -138,8 +138,45 @@ export let Before = mapAction("Before");
  */
 export let After = mapAction("After");
 
-export interface IHookFunction {
-  (value: "verify" | "open" | "message"): any;
-}
-
-export let Hook: IHookFunction = mapAction("Hook");
+/**
+ * @since 2.0.0
+ * @decorator
+ * @function
+ * @name Hook
+ *
+ * @param {String} value One of "verify"|"open"|"message"
+ *
+ * @description
+ * Define a WebSocket method hook to be called for one of the actions "verify",
+ * "open", or "message". All hooks support injection with {@link Inject} and {@link Param}.
+ *
+ * The "verify" hook is called before the socket is fully established. If you want to deny
+ * opening the socket just throw an {@link HttpError}.
+ *
+ * When the socket is opened the "open" hook is called. You can inject the {@link Socket}
+ * as parameter in this method in order to get access to the underlying Socket API.
+ *
+ * To receive and handle messages from the other side provide a "message" hook. You can inject
+ * a parameter "message" there which is the data received over the socket.
+ *
+ * @example
+ * import {WebSocket, Hook, BaseRequest} from "typeix";
+ *
+ * \@WebSocket({...})
+ * export class MySocket {
+ *   \@Inject(BaseRequest)
+ *   private readonly request: BaseRequest;
+ *
+ *   \@Hook("verify")
+ *   verify(): void {
+ *     if (!this.request.getRequestHeader("my-header") === "approved") {
+ *       throw new HttpError(403, "You are not approved");
+ *     }
+ *   }
+ *
+ *   \@Hook("open")
+ *   open(@Inject(Socket) socket: Socket) {
+ *   }
+ * }
+ */
+export let Hook: (value: "verify" | "open" | "message") => any = mapAction("Hook");

--- a/src/decorators/action.ts
+++ b/src/decorators/action.ts
@@ -138,4 +138,8 @@ export let Before = mapAction("Before");
  */
 export let After = mapAction("After");
 
-export let Hook = mapAction("Hook");
+export interface IHookFunction {
+  (value: "verify" | "open" | "message"): any;
+}
+
+export let Hook: IHookFunction = mapAction("Hook");

--- a/src/decorators/controller.ts
+++ b/src/decorators/controller.ts
@@ -8,7 +8,7 @@ import {IControllerMetadata} from "../interfaces/icontroller";
  * @function
  * @name Controller
  *
- * @param {IModuleMetadata} config
+ * @param {IControllerMetadata} config
  * @returns {function(any): any}
  *
  * @description

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,5 +1,6 @@
-export {Action, Before, After, BeforeEach, AfterEach} from "./action";
+export {Action, Before, After, BeforeEach, AfterEach, Hook} from "./action";
 export {Controller} from "./controller";
+export {WebSocket} from "./websocket";
 export {Inject} from "./inject";
 export {Filter} from "./filter";
 export {Injectable} from "./injectable";

--- a/src/decorators/inject.ts
+++ b/src/decorators/inject.ts
@@ -34,6 +34,9 @@ export let Inject = (value: Function | string, isMutable?: boolean) => {
     if (Metadata.isDescriptor(paramIndex)) {
       throw new TypeError(`@${type} is not allowed ${Metadata.getName(Class, "on class ")} on ${paramIndex.value}
       @Inject is allowed only as param type!`);
+    } else if (isUndefined(value)) {
+      throw new TypeError(`@Inject is not allowed with undefined value ${Metadata.getName(Class, "on ")}.${key}
+      - make sure there are no circular dependencies`);
     }
 
     metadata.push(isUndefined(paramIndex) ? {

--- a/src/decorators/provider.ts
+++ b/src/decorators/provider.ts
@@ -1,6 +1,7 @@
 import {IProvider} from "../interfaces/iprovider";
-import {isPresent, isArray, isClass} from "../core";
+import {isArray, isClass, isPresent} from "../core";
 import {Metadata} from "../injector/metadata";
+
 /**
  * @since 1.0.0
  * @decorator
@@ -21,11 +22,10 @@ import {Metadata} from "../injector/metadata";
  *    }
  * }
  */
-export let Provider = (config: Array<IProvider|Function>) => {
+export let Provider = (config: Array<IProvider | Function>) => {
   return (Class) => {
     if (!isClass(Class)) {
-      throw new TypeError(`Provider is only allowed on class definition! 
-      Error found on ${Class.toString()}`);
+      throw new TypeError(`Provider is only allowed on class definition! Error found on ${Class.toString()}`);
     } else if (isPresent(config) && !isArray(config)) {
       throw new TypeError(`Provider value must be array of IProvider`);
     }

--- a/src/decorators/websocket.ts
+++ b/src/decorators/websocket.ts
@@ -12,7 +12,7 @@ import {IWebSocketMetadata} from "../interfaces/iwebsocket";
  * @returns {function(any): any}
  *
  * @description
- * Define controller of application
+ * Define endpoint of application
  */
 export let WebSocket = (config: IWebSocketMetadata) => (Class) => {
   if (!isArray(config.providers)) {

--- a/src/decorators/websocket.ts
+++ b/src/decorators/websocket.ts
@@ -1,18 +1,37 @@
 import {isArray, isClass} from "../core";
 import {Metadata} from "../injector/metadata";
-import {IWebSocketMetadata} from "../interfaces/iwebsocket";
+import {IWebSocketMetadata} from "../interfaces";
 
 /**
- * WebSocket
+ * @since 2.0.0
  * @decorator
  * @function
  * @name WebSocket
  *
- * @param {IWebSocketMetadata} config
+ * @param {IWebSocketMetadata} config WebSocket configuration
  * @returns {function(any): any}
  *
  * @description
- * Define endpoint of application
+ * Defines a WebSocket endpoint of an application.
+ *
+ * The {@link Inject} decorator can be used for class members in the same way
+ * as for controllers.
+ *
+ * If you want to access the underlying request that opened the socket you can
+ * inject {@link BaseRequest} which provides a minimal interface for basic access.
+ *
+ * @example
+ * import {WebSocket} from "typeix";
+ *
+ * \@WebSocket({
+ *   name: "mySocket"
+ * })
+ * class MySocketEndpoint {
+ *   \@Inject(BaseRequest)
+ *   private readonly request: BaseRequest;
+ *
+ *   ...
+ * }
  */
 export let WebSocket = (config: IWebSocketMetadata) => (Class) => {
   if (!isArray(config.providers)) {

--- a/src/decorators/websocket.ts
+++ b/src/decorators/websocket.ts
@@ -1,0 +1,27 @@
+import {isArray, isClass} from "../core";
+import {Metadata} from "../injector/metadata";
+import {IWebSocketMetadata} from "../interfaces/iwebsocket";
+
+/**
+ * WebSocket
+ * @decorator
+ * @function
+ * @name WebSocket
+ *
+ * @param {IWebSocketMetadata} config
+ * @returns {function(any): any}
+ *
+ * @description
+ * Define controller of application
+ */
+export let WebSocket = (config: IWebSocketMetadata) => (Class) => {
+  if (!isArray(config.providers)) {
+    config.providers = [];
+  }
+  config.providers = config.providers.map(ProviderClass => Metadata.verifyProvider(ProviderClass));
+  if (!isClass(Class)) {
+    throw new TypeError(`@WebSocket is allowed only on class`);
+  }
+  Metadata.setComponentConfig(Class, config);
+  return Class;
+};

--- a/src/error.ts
+++ b/src/error.ts
@@ -10,7 +10,7 @@ import {isTruthy} from "./core";
  * @param {Object} data
  * @constructor
  * @description
- * HttpException use it in controller actions
+ * HttpException use it in endpoint actions
  */
 export class HttpError extends Error {
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,10 @@ export {
   After,
   BeforeEach,
   AfterEach,
+  Hook,
   Filter,
   Controller,
+  WebSocket,
   Inject,
   Injectable,
   Module,
@@ -37,9 +39,11 @@ export {
  */
 export {
   IControllerMetadata,
+  IWebSocketMetadata,
   IModuleMetadata,
   IProvider,
   IAfterConstruct,
+  IAfterClose,
   IFilter,
   Route,
   RouteRuleConfig,
@@ -71,9 +75,11 @@ export {
   getModule,
   Request,
   Status,
+  Socket,
   fakeHttpServer,
   fakeControllerActionCall,
   FakeServerApi,
+  FakeWebSocketApi,
   FakeResponseApi,
   IFakeServerConfig
 } from "./server/index";

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ export {
  */
 export {
   httpServer,
+  HttpOptions,
   getModule,
   Request,
   Status,

--- a/src/interfaces/imodule.ts
+++ b/src/interfaces/imodule.ts
@@ -8,7 +8,6 @@ import {Injector} from "../injector/injector";
  * @param {Array<Function|IProvider>} imports
  * @param {Array<Function|IProvider>} exports
  * @param {String} name
- * @param {Array<RouteRuleConfig>} routes
  * @param {Array<IModuleMetadata>} modules
  * @param {Array<IProvider|Function>} controllers
  * @param {Array<IProvider|Function>} providers
@@ -20,7 +19,6 @@ export interface IModuleMetadata {
   imports?: Array<Function | IProvider>;
   exports?: Array<Function | IProvider>;
   name?: string;
-  routes?: Array<RouteRuleConfig>;
   controllers?: Array<IProvider | Function>;
   providers?: Array<IProvider | Function>;
 }

--- a/src/interfaces/imodule.ts
+++ b/src/interfaces/imodule.ts
@@ -55,6 +55,6 @@ export interface IResolvedModule {
   module: IModule;
   data?: Array<Buffer>;
   resolvedRoute: IResolvedRoute;
-  controller: string;
+  endpoint: string;
   action: string;
 }

--- a/src/interfaces/imodule.ts
+++ b/src/interfaces/imodule.ts
@@ -20,6 +20,7 @@ export interface IModuleMetadata {
   exports?: Array<Function | IProvider>;
   name?: string;
   controllers?: Array<IProvider | Function>;
+  sockets?: Array<IProvider | Function>;
   providers?: Array<IProvider | Function>;
 }
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -3,3 +3,4 @@ export {IFilter} from "./ifilter";
 export {IModuleMetadata} from "./imodule";
 export {IProvider, IAfterConstruct} from "./iprovider";
 export {Route, RouteRuleConfig, IResolvedRoute, Headers} from "./iroute";
+export {IWebSocketMetadata, IAfterClose} from "./iwebsocket";

--- a/src/interfaces/iwebsocket.ts
+++ b/src/interfaces/iwebsocket.ts
@@ -14,15 +14,3 @@ export interface IWebSocketMetadata {
   name: string;
   providers?: Array<IProvider | Function>;
 }
-
-export interface IWebSocket {
-
-  getReadyState(): number;
-
-  close(status?: number, data?: string): void;
-
-  send(data: any, cb?: (err: Error) => void): void;
-
-  send(data: any, options: { mask?: boolean; binary?: boolean }, cb?: (err: Error) => void): void;
-
-}

--- a/src/interfaces/iwebsocket.ts
+++ b/src/interfaces/iwebsocket.ts
@@ -1,0 +1,16 @@
+import {IProvider} from "./iprovider";
+
+/**
+ * @since 1.1.0
+ * @interface
+ * @name IWebSocketMetadata
+ * @param {String} name
+ * @param {Array<IProvider|Function>} providers
+ *
+ * @description
+ * WebSocket metadata
+ */
+export interface IWebSocketMetadata {
+  name: string;
+  providers?: Array<IProvider | Function>;
+}

--- a/src/interfaces/iwebsocket.ts
+++ b/src/interfaces/iwebsocket.ts
@@ -14,3 +14,7 @@ export interface IWebSocketMetadata {
   name: string;
   providers?: Array<IProvider | Function>;
 }
+
+export interface IAfterClose {
+  afterClose(): void;
+}

--- a/src/interfaces/iwebsocket.ts
+++ b/src/interfaces/iwebsocket.ts
@@ -1,20 +1,37 @@
 import {IProvider} from "./iprovider";
 
 /**
- * @since 1.1.0
+ * @since 2.0.0
  * @interface
  * @name IWebSocketMetadata
- * @param {String} name
- * @param {Array<IProvider|Function>} providers
  *
  * @description
  * WebSocket metadata
  */
 export interface IWebSocketMetadata {
+  /**
+   * Name of the socket - used in route definition
+   */
   name: string;
+
+  /**
+   * Additional providers for injector
+   */
   providers?: Array<IProvider | Function>;
 }
 
+/**
+ * @since 2.0.0
+ * @interface
+ * @name IAfterClose
+ *
+ * @description
+ * Provides a method to implement for a {@link WebSocket} in order to be
+ * called when the socket has been closed, e.g. to free up resources.
+ */
 export interface IAfterClose {
+  /**
+   * Called after the socket has already been closed.
+   */
   afterClose(): void;
 }

--- a/src/interfaces/iwebsocket.ts
+++ b/src/interfaces/iwebsocket.ts
@@ -14,3 +14,15 @@ export interface IWebSocketMetadata {
   name: string;
   providers?: Array<IProvider | Function>;
 }
+
+export interface IWebSocket {
+
+  getReadyState(): number;
+
+  close(status?: number, data?: string): void;
+
+  send(data: any, cb?: (err: Error) => void): void;
+
+  send(data: any, options: { mask?: boolean; binary?: boolean }, cb?: (err: Error) => void): void;
+
+}

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -4,7 +4,7 @@ import {IncomingMessage, ServerResponse} from "http";
 import {isArray, isEqual, isFalsy, isTruthy, uuid} from "../core";
 import {IModule, IModuleMetadata} from "../interfaces/imodule";
 import {Metadata} from "../injector/metadata";
-import {RequestResolver} from "./request-resolver";
+import {HttpRequestResolver} from "./request-resolver";
 import {parse} from "url";
 import {IProvider} from "../interfaces/iprovider";
 import {EventEmitter} from "events";
@@ -179,11 +179,11 @@ export function fireRequest(modules: Array<IModule>,
   let rootInjector: Injector = getModule(modules).injector;
   let logger: Logger = rootInjector.get(Logger);
   /**
-   * Create RequestResolver injector
+   * Create HttpRequestResolver injector
    */
   let routeResolverInjector = Injector.createAndResolveChild(
     rootInjector,
-    RequestResolver,
+    HttpRequestResolver,
     [
       {provide: "url", useValue: parse(request.url, true)},
       {provide: "UUID", useValue: uuid()},
@@ -197,9 +197,9 @@ export function fireRequest(modules: Array<IModule>,
     ]
   );
   /**
-   * Get RequestResolver instance
+   * Get HttpRequestResolver instance
    */
-  let rRouteResolver: RequestResolver = routeResolverInjector.get(RequestResolver);
+  let rRouteResolver: HttpRequestResolver = routeResolverInjector.get(HttpRequestResolver);
 
   /**
    * On finish destroy injector

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -163,7 +163,7 @@ export function createModule(Class: IProvider | Function, sibling?: Injector, mo
  * @since 1.0.0
  * @function
  * @name fireRequest
- * @param {Array<IModule>} modules list of all modules bootstraped
+ * @param {Array<IModule>} modules list of all modules bootstrapped
  * @param {IncomingMessage} request event emitter
  * @param {ServerResponse} response event emitter
  * @return {string|Buffer} data from controller
@@ -176,8 +176,8 @@ export function fireRequest(modules: Array<IModule>,
                             request: IncomingMessage,
                             response: ServerResponse): Promise<string | Buffer> {
 
-  let rootInjector = getModule(modules).injector;
-  let logger = rootInjector.get(Logger);
+  let rootInjector: Injector = getModule(modules).injector;
+  let logger: Logger = rootInjector.get(Logger);
   /**
    * Create RequestResolver injector
    */

--- a/src/server/controller-resolver.ts
+++ b/src/server/controller-resolver.ts
@@ -1,6 +1,6 @@
 import {IncomingMessage, ServerResponse} from "http";
-import {getMethodName, Methods} from "../router/router";
-import {isArray, isDate, isFalsy, isNumber, isPresent, isString, isTruthy} from "../core";
+import {getMethodName} from "../router/router";
+import {isArray, isFalsy, isPresent} from "../core";
 import {Logger} from "../logger/logger";
 import {Injector} from "../injector/injector";
 import {IProvider} from "../interfaces/iprovider";
@@ -12,18 +12,12 @@ import {Injectable} from "../decorators/injectable";
 import {Inject} from "../decorators/inject";
 import {FUNCTION_KEYS, FUNCTION_PARAMS, Metadata} from "../injector/metadata";
 import {IControllerMetadata} from "../interfaces/icontroller";
-import {IConnection} from "../interfaces/iconnection";
 import {IAction} from "../interfaces/iaction";
 import {IParam} from "../interfaces/iparam";
 import {Status} from "./status-code";
+import {Request} from "./request";
 import {ERROR_KEY} from "./request-resolver";
-import {MultiPart, MultiPartField, MultiPartFile} from "../parsers/multipart";
 
-/**
- * Cookie parse regex
- * @type {RegExp}
- */
-const COOKIE_PARSE_REGEX = /(\w+[^=]+)=([^;]+)/g;
 const CHAIN_KEY = "__chain__";
 
 /**
@@ -194,6 +188,18 @@ export class ControllerResolver {
     return this.request;
   }
 
+  getResolvedRoute(): IResolvedRoute {
+    return this.resolvedRoute;
+  }
+
+  getId(): string {
+    return this.id;
+  }
+
+  getBody(): Array<Buffer> {
+    return this.data;
+  }
+
   /**
    * @since 1.0.0
    * @function
@@ -206,34 +212,6 @@ export class ControllerResolver {
   getServerResponse(): ServerResponse {
     return this.response;
   }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getBody
-   * @private
-   *
-   * @description
-   * Get request body if present only on POST, PUT, PATCH
-   */
-  getBody(): Buffer {
-    return Buffer.concat(this.data);
-  }
-
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getUUID
-   * @private
-   *
-   * @description
-   * Return uuid created with this request
-   */
-  getUUID(): string {
-    return this.id;
-  }
-
 
   /**
    * @since 1.0.0
@@ -251,8 +229,8 @@ export class ControllerResolver {
     this.response.once("close", () => this.destroy());
 
     // set request reflection
-    let reflectionInjector = Injector.createAndResolveChild(this.injector, Request, [
-      {provide: ControllerResolver, useValue: this}
+    const reflectionInjector = Injector.createAndResolveChild(this.injector, Request, [
+      {provide: "controllerResolver", useValue: this}
     ]);
 
     return this.processController(reflectionInjector, this.controllerProvider, this.actionName);
@@ -585,343 +563,6 @@ export class ControllerResolver {
       method: getMethodName(this.resolvedRoute.method),
       route: this.resolvedRoute.route,
       url: this.request.url
-    });
-  }
-}
-
-/**
- * @since 1.0.0
- * @class
- * @name Request
- * @constructor
- * @description
- * Get request reflection to limit public api
- *
- * @private
- */
-@Injectable()
-export class Request {
-
-  /**
-   * @param ControllerResolver
-   * @description
-   * Current internal ControllerResolver instance
-   */
-  @Inject(ControllerResolver)
-  private controllerResolver: ControllerResolver;
-
-  /**
-   * @param ResolvedRoute
-   * @description
-   * Current internal resolved route
-   */
-  @Inject("resolvedRoute")
-  private resolvedRoute: IResolvedRoute;
-  /**
-   * @param cookies
-   * @description
-   * Cookies object are stored to this object first time thy are parsed
-   */
-  private cookies: { [key: string]: string };
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#onDestroy
-   *
-   * @description
-   * Add destroy event to public api
-   */
-  onDestroy(callback: (...args: any[]) => void): void {
-    this.controllerResolver.getEventEmitter().once("destroy", callback);
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getConnection
-   *
-   * @description
-   * Get connection data
-   */
-  getConnection(): IConnection {
-    let request = this.controllerResolver.getIncomingMessage();
-    return {
-      uuid: this.controllerResolver.getUUID(),
-      method: request.method,
-      url: request.url,
-      httpVersion: request.httpVersion,
-      httpVersionMajor: request.httpVersionMajor,
-      httpVersionMinor: request.httpVersionMinor,
-      remoteAddress: request.connection.remoteAddress,
-      remoteFamily: request.connection.remoteFamily,
-      remotePort: request.connection.remotePort,
-      localAddress: request.connection.localAddress,
-      localPort: request.connection.localPort
-    };
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getCookies
-   *
-   * @description
-   * Return parsed cookies
-   */
-  getCookies(): { [key: string]: string } {
-
-    if (isPresent(this.cookies)) {
-      return this.cookies;
-    }
-    // get cookie string
-    let cookie: string = this.getRequestHeader("Cookie");
-
-    if (isPresent(cookie)) {
-
-      this.cookies = {};
-
-      // parse cookies
-      cookie.match(COOKIE_PARSE_REGEX)
-        .map(item => item.split(COOKIE_PARSE_REGEX).slice(1, -1))
-        .map(item => {
-          return {
-            key: item.shift(),
-            value: item.shift()
-          };
-        })
-        .forEach(item => {
-          this.cookies[item.key] = item.value;
-        });
-
-      return this.cookies;
-    }
-
-    return {};
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getCookie
-   *
-   * @description
-   * Return request headers
-   */
-  getCookie(name: string): string {
-    let cookies = this.getCookies();
-    return cookies[name];
-  }
-
-  /**
-   * @since 0.0.1
-   * @function
-   * @name Request#setResponseCookie
-   * @param {String} key cookie name
-   * @param {String} value cookie value
-   * @param {String|Object|Number} expires expire date
-   * @param {String} path cookie path
-   * @param {String} domain cookie domain
-   * @param {Boolean} isHttpOnly is http only
-   * @description
-   * Sets an cookie header
-   */
-  setCookie(key: string, value: string, expires?: number | Date | string, path?: string, domain?: string, isHttpOnly?: boolean) {
-
-    let cookie = key + "=" + value;
-
-    if (isPresent(expires) && isNumber(expires)) {
-      let date: Date = new Date();
-      date.setTime(date.getTime() + (<number> expires));
-      cookie += "; Expires=";
-      cookie += date.toUTCString();
-    } else if (isPresent(expires) && isString(expires)) {
-      cookie += "; Expires=" + expires;
-    } else if (isPresent(expires) && isDate(expires)) {
-      cookie += "; Expires=";
-      cookie += (<Date> expires).toUTCString();
-    }
-
-    if (isPresent(path)) {
-      cookie += "; Path=" + path;
-    }
-    if (isPresent(domain)) {
-      cookie += "; Domain=" + domain;
-    }
-    if (isTruthy(isHttpOnly)) {
-      cookie += "; HttpOnly";
-    }
-    this.setResponseHeader("Set-cookie", cookie);
-
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getRequestHeaders
-   *
-   * @description
-   * Return request headers
-   */
-  getRequestHeaders(): any {
-    return this.controllerResolver.getIncomingMessage().headers;
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getRequestHeader
-   *
-   * @description
-   * Return request header by name
-   */
-  getRequestHeader(name: string): any {
-    let requestHeaders = this.getRequestHeaders();
-    let headers = isPresent(requestHeaders) ? requestHeaders : {};
-    return headers[name.toLocaleLowerCase()];
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#setResponseHeader
-   * @param {String} name
-   * @param {String} value
-   *
-   * @description
-   * Set response header
-   */
-  setResponseHeader(name: string, value: string | string[]): void {
-    this.controllerResolver.getServerResponse().setHeader(name, value);
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#setContentType
-   * @param {String} value
-   *
-   * @description
-   * Set response content type
-   */
-  setContentType(value: string) {
-    this.controllerResolver.getEventEmitter().emit("contentType", value);
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getParams
-   *
-   * @description
-   * Get all request parameters
-   */
-  getParams(): Object {
-    return isPresent(this.resolvedRoute.params) ? this.resolvedRoute.params : {};
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getParam
-   * @param {string} name
-   *
-   * @description
-   * Get resolve route param
-   */
-  getParam(name: string): string {
-    let params = this.getParams();
-    return params[name];
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getMethod
-   *
-   * @description
-   * Return resolved route method
-   */
-  getMethod(): Methods {
-    return this.resolvedRoute.method;
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getRoute
-   *
-   * @description
-   * Return resolved route name
-   */
-  getRoute(): string {
-    return this.resolvedRoute.route;
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getBody
-   *
-   * @description
-   * Get request body buffer
-   */
-  getBody(): Buffer {
-    return this.controllerResolver.getBody();
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#getBodyAsMultiPart
-   * @param {string} encoding
-   *
-   * @description
-   * Receive body as multipart
-   */
-  getBodyAsMultiPart(encoding = "utf8"): Array<MultiPartField | MultiPartFile> {
-    let buffer: Buffer = this.controllerResolver.getBody();
-    let contentType = this.getRequestHeader("content-type");
-    let parser = new MultiPart(contentType, encoding);
-    return parser.parse(buffer);
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#setStatusCode
-   *
-   * @description
-   * Set status code
-   */
-  setStatusCode(code: Status | number) {
-    this.controllerResolver.getEventEmitter().emit("statusCode", code);
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#stopChain
-   *
-   * @description
-   * Stops action chain
-   */
-  stopChain() {
-    this.controllerResolver.stopChain();
-  }
-
-  /**
-   * @since 1.0.0
-   * @function
-   * @name Request#redirectTo
-   *
-   * @description
-   * Stops action chain
-   */
-  redirectTo(url: string, code: Status | number) {
-    this.stopChain();
-    this.controllerResolver.getEventEmitter().emit("redirectTo", {
-      code, url
     });
   }
 }

--- a/src/server/controller-resolver.ts
+++ b/src/server/controller-resolver.ts
@@ -255,7 +255,7 @@ export class ControllerResolver {
   /**
    * @since 1.0.0
    * @function
-   * @name Request#getMappedAction
+   * @name Request#getMappedHook
    * @private
    * @description
    * Returns a mapped action metadata

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -1,5 +1,5 @@
 import {Injector} from "../injector/injector";
-import {createServer, IncomingMessage, ServerResponse} from "http";
+import {createServer, IncomingMessage, Server, ServerResponse} from "http";
 import {Logger} from "../logger/logger";
 import {isArray, isFunction, isPresent, isString} from "../core";
 import {BOOTSTRAP_MODULE, createModule, fireRequest, getModule} from "./bootstrap";
@@ -8,24 +8,43 @@ import {Metadata} from "../injector/metadata";
 import * as WebSocket from "ws";
 import {fireWebSocket, IWebSocketResult} from "./socket";
 import {HttpError} from "../error";
-import {SocketResolver} from "./socket-resolver";
 
 const TYPEX_SOCKET_ID_HEADER = "__typeix_id";
+
+/**
+ * @since 2.0.0
+ * @interface
+ *
+ * @description
+ * Configuration options for the HTTP server
+ */
+export interface HttpOptions {
+  /**
+   * Port for the HTTP server to listen on
+   */
+  port: number;
+  /**
+   * Hostname for the HTTP server to listen on
+   */
+  hostname?: string;
+  /**
+   * If enabled the server will also configure WebSockets
+   */
+  enableWebSockets?: boolean;
+}
 
 /**
  * @since 1.0.0
  * @function
  * @name httpServer
- * @param {Function} Class httpServer class
- * @param {Number} port httpServer on port
- * @param {String} hostname httpServer on hostname
+ * @param {Function} Class Root application module to bootstrap
+ * @param {HttpOptions} options Additional HTTP Server options
  * @returns {Injector}
  *
  * @description
- * Use httpServer function to httpServer an Module.
+ * Run the HTTP server for a given root module.
  */
-export function httpServer(Class: Function, port: number, hostname?: string): Array<IModule> {
-
+export function httpServer(Class: Function, options: HttpOptions): Array<IModule> {
   let metadata: IModuleMetadata = Metadata.getComponentConfig(Class);
   // override bootstrap module
   metadata.name = BOOTSTRAP_MODULE;
@@ -42,15 +61,33 @@ export function httpServer(Class: Function, port: number, hostname?: string): Ar
       fireRequest(modules, request, response)
   );
 
-  if (isString(hostname)) {
-    server.listen(port, hostname);
+  if (isString(options.hostname)) {
+    server.listen(options.port, options.hostname);
   } else {
-    server.listen(port);
+    server.listen(options.port);
   }
 
-  logger.info("Module.info: Server started", {port, hostname});
+  logger.info("Module.info: Server started", options);
   server.on("error", (e) => logger.error(e.stack));
 
+  if (options.enableWebSockets) {
+    configureAndStartWebSockets(modules, logger, server);
+  }
+
+  return modules;
+}
+
+/**
+ * @since 2.0.0
+ * @function
+ * @param {Array<IModule>} modules The list of bootstrapped modules
+ * @param {Logger} logger The logger instance
+ * @param {"http".Server} server Configured HTTP server
+ *
+ * @description
+ * Configures and starts the WebSockets extensions
+ */
+function configureAndStartWebSockets(modules: Array<IModule>, logger: Logger, server: Server) {
   const socketResultMap: Map<string, IWebSocketResult> = new Map();
   const wss = new WebSocket.Server({
     server,
@@ -97,6 +134,4 @@ export function httpServer(Class: Function, port: number, hostname?: string): Ar
     }
   });
   wss.on("error", (e) => logger.error(e.stack));
-
-  return modules;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,5 @@
 export {httpServer} from "./http";
 export {getModule} from "./bootstrap";
-export {Request} from "./controller-resolver";
+export {Request} from "./request";
 export {Status} from "./status-code";
 export {fakeHttpServer, fakeControllerActionCall, FakeServerApi, FakeResponseApi, IFakeServerConfig} from "./mocks";

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,4 @@
-export {httpServer} from "./http";
+export {httpServer, HttpOptions} from "./http";
 export {getModule} from "./bootstrap";
 export {BaseRequest, Request} from "./request";
 export {Socket} from "./socket";

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,6 @@
 export {httpServer} from "./http";
 export {getModule} from "./bootstrap";
-export {Request} from "./request";
+export {BaseRequest, Request} from "./request";
+export {Socket} from "./socket";
 export {Status} from "./status-code";
-export {fakeHttpServer, fakeControllerActionCall, FakeServerApi, FakeResponseApi, IFakeServerConfig} from "./mocks";
+export {fakeHttpServer, fakeControllerActionCall, FakeServerApi, FakeResponseApi, FakeWebSocketApi, IFakeServerConfig} from "./mocks";

--- a/src/server/mocks.ts
+++ b/src/server/mocks.ts
@@ -365,12 +365,12 @@ export class FakeServerApi {
   /**
    * @since 1.1.0
    * @function
-   * @name FakeServerApi#openSocket
+   * @name FakeServerApi#createSocket
    * @return {any}
    * @description
-   * Open a fake websocket connection
+   * Create a fake websocket connection
    */
-  openSocket(url: string, headers?: Object): Promise<FakeWebSocketApi> {
+  createSocket(url: string, headers?: Object): Promise<FakeWebSocketApi> {
     const request = new FakeIncomingMessage();
     request.method = "GET";
     request.url = url;
@@ -693,8 +693,6 @@ class FakeServerResponse extends Writable implements ServerResponse {
   flushHeaders(): void {
     console.log("flushHeaders");
   }
-
-
 }
 
 class FakeWebSocket implements FakeWebSocketApi {
@@ -728,6 +726,7 @@ class FakeWebSocket implements FakeWebSocketApi {
   close(): void {
     this.readyState = 2;
     this.eventEmitter.emit("close");
+    this.socket.finished();
     this.eventEmitter.removeAllListeners();
   }
 

--- a/src/server/mocks.ts
+++ b/src/server/mocks.ts
@@ -138,6 +138,25 @@ export interface FakeResponseApi {
 }
 
 /**
+ * @since 1.1.0
+ * @class
+ * @name FakeWebSocketApi
+ * @description
+ * Fake API used to test websockets
+ */
+export interface FakeWebSocketApi {
+  /**
+   * @since 1.1.0
+   * @method
+   * @name FakeWebSocketApi#send
+   * @param {string} data Data to send
+   * @description
+   * Send data over the fake websocket
+   */
+  send(data: string): void;
+}
+
+/**
  * @since 1.0.0
  * @class
  * @name FakeServerApi
@@ -311,6 +330,27 @@ export class FakeServerApi {
       request.emit("end");
     });
     return this.request(request, new FakeServerResponse());
+  }
+
+  /**
+   * @since 1.1.0
+   * @function
+   * @name FakeServerApi#openSocket
+   * @return {any}
+   * @description
+   * Open a fake websocket connection
+   */
+  openSocket(url: string): FakeWebSocketApi {
+    console.log("creating fake socket:", url);
+    const request = new FakeIncomingMessage();
+    request.method = "GET";
+    request.url = url;
+
+    const ws: FakeWebSocketApi = {
+      send: data => console.log("fake socket received data", data)
+    };
+
+    return ws;
   }
 
   /**
@@ -616,7 +656,6 @@ class FakeServerResponse extends Writable implements ServerResponse {
   flushHeaders(): void {
     console.log("flushHeaders");
   }
-
 
 
 }

--- a/src/server/mocks.ts
+++ b/src/server/mocks.ts
@@ -371,7 +371,6 @@ export class FakeServerApi {
    * Open a fake websocket connection
    */
   openSocket(url: string, headers?: Object): Promise<FakeWebSocketApi> {
-    console.log("creating fake socket:", url);
     const request = new FakeIncomingMessage();
     request.method = "GET";
     request.url = url;
@@ -720,8 +719,9 @@ class FakeWebSocket implements FakeWebSocketApi {
       .then(() => {
         this.readyState = 1;
         this.eventEmitter.on("close", () => this.readyState = 3);
-      }, () => {
+      }, (error) => {
         this.readyState = 3;
+        throw error;
       });
   }
 
@@ -732,6 +732,9 @@ class FakeWebSocket implements FakeWebSocketApi {
   }
 
   send(data: WebSocket.Data): void {
+    if (this.readyState !== 1) {
+      throw new Error("Socket must be opened first");
+    }
     this.eventEmitter.emit("message", data);
   }
 

--- a/src/server/mocks.ts
+++ b/src/server/mocks.ts
@@ -370,11 +370,12 @@ export class FakeServerApi {
    * @description
    * Open a fake websocket connection
    */
-  openSocket(url: string): Promise<FakeWebSocketApi> {
+  openSocket(url: string, headers?: Object): Promise<FakeWebSocketApi> {
     console.log("creating fake socket:", url);
     const request = new FakeIncomingMessage();
     request.method = "GET";
     request.url = url;
+    request.headers = headers;
 
     return fireWebSocket(this.getModules(), request)
       .then(result => {

--- a/src/server/request-resolver.ts
+++ b/src/server/request-resolver.ts
@@ -110,7 +110,7 @@ export enum RenderType {
 /**
  * @since 1.0.0
  * @class
- * @name RequestResolver
+ * @name HttpRequestResolver
  * @constructor
  * @description
  * Get current request and resolve module and route
@@ -118,7 +118,7 @@ export enum RenderType {
  * @private
  */
 @Injectable()
-export class RequestResolver extends BaseRequestResolver implements IAfterConstruct {
+export class HttpRequestResolver extends BaseRequestResolver implements IAfterConstruct {
 
   /**
    * @param ServerResponse
@@ -162,7 +162,7 @@ export class RequestResolver extends BaseRequestResolver implements IAfterConstr
   /**
    * @since 1.0.0
    * @function
-   * @name RequestResolver#getControllerProvider
+   * @name HttpRequestResolver#getControllerProvider
    * @private
    * @description
    * Returns a controller provider
@@ -191,7 +191,7 @@ export class RequestResolver extends BaseRequestResolver implements IAfterConstr
   /**
    * @since 1.0.0
    * @function
-   * @name RequestResolver#afterConstruct
+   * @name HttpRequestResolver#afterConstruct
    *
    * @private
    * @description
@@ -206,7 +206,7 @@ export class RequestResolver extends BaseRequestResolver implements IAfterConstr
   /**
    * @since 1.0.0
    * @function
-   * @name RequestResolver#processError
+   * @name HttpRequestResolver#processError
    * @param {Object} data
    * @param {Boolean} isCustom
    *
@@ -263,7 +263,7 @@ export class RequestResolver extends BaseRequestResolver implements IAfterConstr
   /**
    * @since 1.0.0
    * @function
-   * @name RequestResolver#render
+   * @name HttpRequestResolver#render
    * @param {Buffer|String} response
    * @param {RenderType} type
    *
@@ -324,7 +324,7 @@ export class RequestResolver extends BaseRequestResolver implements IAfterConstr
   /**
    * @since 1.0.0
    * @function
-   * @name RequestResolver#processModule
+   * @name HttpRequestResolver#processModule
    * @private
    * @description
    * Resolve route and deliver resolved module
@@ -337,7 +337,7 @@ export class RequestResolver extends BaseRequestResolver implements IAfterConstr
       {provide: "response", useValue: this.response},
       {provide: "url", useValue: this.url},
       {provide: "UUID", useValue: this.id},
-      {provide: "controllerProvider", useValue: RequestResolver.getControllerProvider(resolvedModule)},
+      {provide: "controllerProvider", useValue: HttpRequestResolver.getControllerProvider(resolvedModule)},
       {provide: "actionName", useValue: resolvedModule.action},
       {provide: "resolvedRoute", useValue: resolvedModule.resolvedRoute},
       {provide: "isChainStopped", useValue: false},
@@ -370,7 +370,7 @@ export class RequestResolver extends BaseRequestResolver implements IAfterConstr
   /**
    * @since 1.0.0
    * @function
-   * @name RequestResolver#getResolvedModule
+   * @name HttpRequestResolver#getResolvedModule
    * @private
    * @description
    * Resolve route and deliver resolved module
@@ -398,7 +398,7 @@ export class RequestResolver extends BaseRequestResolver implements IAfterConstr
   /**
    * @since 1.0.0
    * @function
-   * @name RequestResolver#process
+   * @name HttpRequestResolver#process
    * @private
    * @description
    * Resolve route and deliver resolved module
@@ -449,4 +449,18 @@ export class RequestResolver extends BaseRequestResolver implements IAfterConstr
       .catch(data => this.render(data, RenderType.CUSTOM_ERROR_HANDLER))
       .catch(data => this.render(data, RenderType.DEFAULT_ERROR_HANDLER));
   }
+}
+
+/**
+ * @since 1.1.0
+ * @class
+ * @name SocketRequestResolver
+ * @constructor
+ * @description
+ * Handles the current request and resolves to a socket
+ *
+ * @private
+ */
+@Injectable()
+export class SocketRequestResolver extends BaseRequestResolver {
 }

--- a/src/server/request-resolver.ts
+++ b/src/server/request-resolver.ts
@@ -517,6 +517,8 @@ export class SocketRequestResolver extends BaseRequestResolver {
     );
 
     const socketResolver: SocketResolver = childInjector.get(SocketResolver);
+    this.logger.debug("SocketRequestResolver.processModule: resolved SocketResolver");
+
     socketResolver.getEventEmitter().on("destroy", () => {
       childInjector.destroy();
     });
@@ -525,6 +527,7 @@ export class SocketRequestResolver extends BaseRequestResolver {
   }
 
   protected handleError(data: any): any {
+    this.logger.error("SocketRequestResolver.handleError: an error occurred", {data});
     throw new HttpError(Status.Internal_Server_Error, "Could not resolve socket");
   }
 }

--- a/src/server/request-resolver.ts
+++ b/src/server/request-resolver.ts
@@ -528,6 +528,9 @@ export class SocketRequestResolver extends BaseRequestResolver {
 
   protected handleError(data: any): any {
     this.logger.error("SocketRequestResolver.handleError: an error occurred", {data});
+    if (data instanceof HttpError) {
+      throw data;
+    }
     throw new HttpError(Status.Internal_Server_Error, "Could not resolve socket");
   }
 }

--- a/src/server/request-resolver.ts
+++ b/src/server/request-resolver.ts
@@ -20,6 +20,77 @@ import {clean} from "../logger/inspect";
 
 export const MODULE_KEY = "__module__";
 export const ERROR_KEY = "__error__";
+
+/**
+ * @since 1.1.0
+ * @private
+ */
+export class BaseRequestResolver {
+  /**
+   * @param IncomingMessage
+   * @description
+   * The current request being processed
+   */
+  @Inject("request")
+  protected readonly request: IncomingMessage;
+
+  /**
+   * @param {Injector} injector
+   * @description
+   * Current injector
+   */
+  @Inject(Injector)
+  protected readonly injector: Injector;
+
+  /**
+   * @param {Logger} logger
+   * @description
+   * Provided by injector
+   */
+  @Inject(Logger)
+  protected readonly logger: Logger;
+
+  /**
+   * @param {Router} router
+   * @description
+   * Provided by injector
+   */
+  @Inject(Router)
+  protected readonly router: Router;
+
+  /**
+   * @param {Array<Buffer>} data
+   * @description
+   * Data received by client on POST, PATCH, PUT requests
+   */
+  @Inject("data")
+  protected readonly data: Array<Buffer>;
+
+  /**
+   * @param {string} id
+   * @description
+   * UUID identifier of request
+   */
+  @Inject("UUID")
+  protected readonly id: string;
+
+  /**
+   * @param {Url} url
+   * @description
+   * Parsed request url
+   */
+  @Inject("url")
+  protected readonly url: Url;
+
+  /**
+   * @param {Url} url
+   * @description
+   * Parsed request url
+   */
+  @Inject("modules")
+  protected readonly modules: Array<IModule>;
+}
+
 /**
  * @since 1.0.0
  * @enum
@@ -35,6 +106,7 @@ export enum RenderType {
   CUSTOM_ERROR_HANDLER,
   DEFAULT_ERROR_HANDLER
 }
+
 /**
  * @since 1.0.0
  * @class
@@ -46,15 +118,7 @@ export enum RenderType {
  * @private
  */
 @Injectable()
-export class RequestResolver implements IAfterConstruct {
-
-  /**
-   * @param IncomingMessage
-   * @description
-   * Value provided by injector which handles request input
-   */
-  @Inject("request")
-  private request: IncomingMessage;
+export class RequestResolver extends BaseRequestResolver implements IAfterConstruct {
 
   /**
    * @param ServerResponse
@@ -62,62 +126,7 @@ export class RequestResolver implements IAfterConstruct {
    * Value provided by injector which handles response output
    */
   @Inject("response")
-  private response: ServerResponse;
-
-  /**
-   * @param {Injector} injector
-   * @description
-   * Current injector
-   */
-  @Inject(Injector)
-  private injector: Injector;
-  /**
-   * @param {Logger} logger
-   * @description
-   * Provided by injector
-   */
-  @Inject(Logger)
-  private logger: Logger;
-
-  /**
-   * @param {Router} router
-   * @description
-   * Provided by injector
-   */
-  @Inject(Router)
-  private router: Router;
-
-  /**
-   * @param {Array<Buffer>} data
-   * @description
-   * Data received by client on POST, PATCH, PUT requests
-   */
-  @Inject("data")
-  private data: Array<Buffer>;
-
-  /**
-   * @param {string} id
-   * @description
-   * UUID identifier of request
-   */
-  @Inject("UUID")
-  private id: string;
-
-  /**
-   * @param {Url} url
-   * @description
-   * Parsed request url
-   */
-  @Inject("url")
-  private url: Url;
-
-  /**
-   * @param {Url} url
-   * @description
-   * Parsed request url
-   */
-  @Inject("modules")
-  private modules: Array<IModule>;
+  private readonly response: ServerResponse;
 
   /**
    * @param {Number} statusCode
@@ -140,7 +149,7 @@ export class RequestResolver implements IAfterConstruct {
    * Responsible for handling events
    */
   @Inject(EventEmitter)
-  private eventEmitter: EventEmitter;
+  private readonly eventEmitter: EventEmitter;
 
   /**
    * @param {String} redirectTo

--- a/src/server/request.ts
+++ b/src/server/request.ts
@@ -1,0 +1,408 @@
+import {isDate, isNumber, isPresent, isString, isTruthy} from "../core";
+import {Inject, Injectable} from "../decorators";
+import {IResolvedRoute} from "../interfaces";
+import {MultiPart, MultiPartField, MultiPartFile} from "../parsers";
+import {Status} from "./status-code";
+import {Methods} from "../router";
+import {IConnection} from "../interfaces/iconnection";
+import {IncomingMessage} from "http";
+import {ControllerResolver} from "./controller-resolver";
+
+/**
+ * Cookie parse regex
+ * @type {RegExp}
+ */
+const COOKIE_PARSE_REGEX = /(\w+[^=]+)=([^;]+)/g;
+
+export abstract class AbstractRequest {
+  /**
+   * @param cookies
+   * @description
+   * Cookies object are stored to this object first time they are parsed
+   */
+  private cookies: { [key: string]: string };
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getConnection
+   *
+   * @description
+   * Get connection data
+   */
+  getConnection(): IConnection {
+    const request = this.getIncomingMessage();
+    return {
+      uuid: this.getId(),
+      method: request.method,
+      url: request.url,
+      httpVersion: request.httpVersion,
+      httpVersionMajor: request.httpVersionMajor,
+      httpVersionMinor: request.httpVersionMinor,
+      remoteAddress: request.connection.remoteAddress,
+      remoteFamily: request.connection.remoteFamily,
+      remotePort: request.connection.remotePort,
+      localAddress: request.connection.localAddress,
+      localPort: request.connection.localPort
+    };
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getCookies
+   *
+   * @description
+   * Return parsed cookies
+   */
+  getCookies(): { [key: string]: string } {
+
+    if (isPresent(this.cookies)) {
+      return this.cookies;
+    }
+    // get cookie string
+    let cookie: string = this.getRequestHeader("Cookie");
+
+    if (isPresent(cookie)) {
+
+      this.cookies = {};
+
+      // parse cookies
+      cookie.match(COOKIE_PARSE_REGEX)
+        .map(item => item.split(COOKIE_PARSE_REGEX).slice(1, -1))
+        .map(item => {
+          return {
+            key: item.shift(),
+            value: item.shift()
+          };
+        })
+        .forEach(item => {
+          this.cookies[item.key] = item.value;
+        });
+
+      return this.cookies;
+    }
+
+    return {};
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getCookie
+   *
+   * @description
+   * Return request headers
+   */
+  getCookie(name: string): string {
+    let cookies = this.getCookies();
+    return cookies[name];
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getRequestHeaders
+   *
+   * @description
+   * Return request headers
+   */
+  getRequestHeaders(): any {
+    return this.getIncomingMessage().headers;
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getRequestHeader
+   *
+   * @description
+   * Return request header by name
+   */
+  getRequestHeader(name: string): any {
+    let requestHeaders = this.getRequestHeaders();
+    let headers = isPresent(requestHeaders) ? requestHeaders : {};
+    return headers[name.toLocaleLowerCase()];
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getParams
+   *
+   * @description
+   * Get all request parameters
+   */
+  getParams(): Object {
+    return isPresent(this.getResolvedRoute().params) ? this.getResolvedRoute().params : {};
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getParam
+   * @param {string} name
+   *
+   * @description
+   * Get resolve route param
+   */
+  getParam(name: string): string {
+    let params = this.getParams();
+    return params[name];
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getMethod
+   *
+   * @description
+   * Return resolved route method
+   */
+  getMethod(): Methods {
+    return this.getResolvedRoute().method;
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getRoute
+   *
+   * @description
+   * Return resolved route name
+   */
+  getRoute(): string {
+    return this.getResolvedRoute().route;
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getBody
+   * @private
+   *
+   * @description
+   * Get request body if present only on POST, PUT, PATCH
+   */
+  getBody(): Buffer {
+    return Buffer.concat(this.getRawData());
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getBodyAsMultiPart
+   * @param {string} encoding
+   *
+   * @description
+   * Get request body as multipart if present only on POST, PUT, PATCH
+   */
+  getBodyAsMultiPart(encoding = "utf8"): Array<MultiPartField | MultiPartFile> {
+    let buffer: Buffer = this.getBody();
+    let contentType = this.getRequestHeader("content-type");
+    let parser = new MultiPart(contentType, encoding);
+    return parser.parse(buffer);
+  }
+
+  abstract getId(): string;
+
+  protected abstract getIncomingMessage(): IncomingMessage;
+
+  protected abstract getResolvedRoute(): IResolvedRoute;
+
+  protected abstract getRawData(): Array<Buffer>;
+}
+
+/**
+ * @since 2.0.0
+ * @class
+ * @name BaseRequest
+ * @constructor
+ * @description
+ * Provides a basic API to the original request - does only support retrieving information.
+ */
+@Injectable()
+export class BaseRequest extends AbstractRequest {
+  @Inject("request")
+  private readonly incomingMessage: IncomingMessage;
+
+  @Inject("UUID")
+  private readonly id: string;
+
+  @Inject("data")
+  private readonly data: Array<Buffer>;
+
+  @Inject("resolvedRoute")
+  private readonly resolvedRoute: IResolvedRoute;
+
+  getId(): string {
+    return this.id;
+  }
+
+  protected getIncomingMessage(): IncomingMessage {
+    return this.incomingMessage;
+  }
+
+  protected getResolvedRoute(): IResolvedRoute {
+    return this.resolvedRoute;
+  }
+
+  protected getRawData(): Array<Buffer> {
+    return this.data;
+  }
+}
+
+/**
+ * @since 1.0.0
+ * @class
+ * @name Request
+ * @constructor
+ * @description
+ * Get request reflection to limit public api
+ */
+@Injectable()
+export class Request extends AbstractRequest {
+  /**
+   * @param ControllerResolver
+   * @description
+   * Current internal ControllerResolver instance
+   */
+  @Inject("controllerResolver")
+  private readonly controllerResolver: ControllerResolver;
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#onDestroy
+   *
+   * @description
+   * Add destroy event to public api
+   */
+  onDestroy(callback: (...args: any[]) => void): void {
+    this.controllerResolver.getEventEmitter().once("destroy", callback);
+  }
+
+  /**
+   * @since 0.0.1
+   * @function
+   * @name Request#setResponseCookie
+   * @param {String} key cookie name
+   * @param {String} value cookie value
+   * @param {String|Object|Number} expires expire date
+   * @param {String} path cookie path
+   * @param {String} domain cookie domain
+   * @param {Boolean} isHttpOnly is http only
+   * @description
+   * Sets an cookie header
+   */
+  setCookie(key: string, value: string, expires?: number | Date | string, path?: string, domain?: string, isHttpOnly?: boolean) {
+
+    let cookie = key + "=" + value;
+
+    if (isPresent(expires) && isNumber(expires)) {
+      let date: Date = new Date();
+      date.setTime(date.getTime() + (<number> expires));
+      cookie += "; Expires=";
+      cookie += date.toUTCString();
+    } else if (isPresent(expires) && isString(expires)) {
+      cookie += "; Expires=" + expires;
+    } else if (isPresent(expires) && isDate(expires)) {
+      cookie += "; Expires=";
+      cookie += (<Date> expires).toUTCString();
+    }
+
+    if (isPresent(path)) {
+      cookie += "; Path=" + path;
+    }
+    if (isPresent(domain)) {
+      cookie += "; Domain=" + domain;
+    }
+    if (isTruthy(isHttpOnly)) {
+      cookie += "; HttpOnly";
+    }
+    this.setResponseHeader("Set-cookie", cookie);
+
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#setResponseHeader
+   * @param {String} name
+   * @param {String} value
+   *
+   * @description
+   * Set response header
+   */
+  setResponseHeader(name: string, value: string | string[]): void {
+    this.controllerResolver.getServerResponse().setHeader(name, value);
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#setContentType
+   * @param {String} value
+   *
+   * @description
+   * Set response content type
+   */
+  setContentType(value: string) {
+    this.controllerResolver.getEventEmitter().emit("contentType", value);
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#setStatusCode
+   *
+   * @description
+   * Set status code
+   */
+  setStatusCode(code: Status | number) {
+    this.controllerResolver.getEventEmitter().emit("statusCode", code);
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#stopChain
+   *
+   * @description
+   * Stops action chain
+   */
+  stopChain() {
+    this.controllerResolver.stopChain();
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#redirectTo
+   *
+   * @description
+   * Stops action chain
+   */
+  redirectTo(url: string, code: Status | number) {
+    this.stopChain();
+    this.controllerResolver.getEventEmitter().emit("redirectTo", {
+      code, url
+    });
+  }
+
+  getId(): string {
+    return this.controllerResolver.getId();
+  }
+
+  protected getIncomingMessage(): IncomingMessage {
+    return this.controllerResolver.getIncomingMessage();
+  }
+
+  protected getResolvedRoute(): IResolvedRoute {
+    return this.controllerResolver.getResolvedRoute();
+  }
+
+  protected getRawData(): Array<Buffer> {
+    return this.controllerResolver.getBody();
+  }
+}

--- a/src/server/socket-resolver.ts
+++ b/src/server/socket-resolver.ts
@@ -1,0 +1,227 @@
+import {IncomingMessage} from "http";
+import {getMethodName} from "../router/router";
+import {isFunction, isPresent} from "../core";
+import {Logger} from "../logger/logger";
+import {Injector} from "../injector/injector";
+import {IProvider, IResolvedRoute} from "../interfaces";
+import {EventEmitter} from "events";
+import {Inject, Injectable} from "../decorators";
+import {FUNCTION_PARAMS, Metadata} from "../injector/metadata";
+import {IParam} from "../interfaces/iparam";
+import {BaseRequest, Request} from "./request";
+import * as WebSocket from "ws";
+
+/**
+ * @since 1.0.0
+ * @class
+ * @name SocketResolver
+ * @constructor
+ * @description
+ * SocketResolver is responsible for handling router result and processing all requests in system
+ * This component is used internally by framework
+ *
+ * @private
+ */
+@Injectable()
+export class SocketResolver {
+
+  /**
+   * @param IncomingMessage
+   * @description
+   * Value provided by injector which handles request input
+   */
+  @Inject("request")
+  private request: IncomingMessage;
+
+  /**
+   * @param {Array<Buffer>} data
+   * @description
+   * Data received by client on initial POST, PATCH, PUT requests
+   */
+  @Inject("data")
+  private data: Array<Buffer>;
+
+  /**
+   * @param {string} id
+   * @description
+   * UUID identifier of request
+   */
+  @Inject("UUID")
+  private id: string;
+
+  /**
+   * @param {IProvider} controllerProvider
+   * @description
+   * Injector
+   */
+  @Inject("socketProvider")
+  private socketProvider: IProvider;
+
+  /**
+   * @param {IResolvedRoute} resolvedRoute
+   * @description
+   * Resolved route from injector
+   */
+  @Inject("resolvedRoute")
+  private resolvedRoute: IResolvedRoute;
+
+  /**
+   * @param {Injector} Injector
+   * @description
+   * Injector which created request
+   */
+  @Inject(Injector)
+  private injector: Injector;
+
+  /**
+   * @param {Logger} logger
+   * @description
+   * Provided by injector
+   */
+  @Inject(Logger)
+  private logger: Logger;
+
+  /**
+   * @param {EventEmitter} eventEmitter
+   * @description
+   * Responsible for handling events
+   */
+  @Inject(EventEmitter)
+  private eventEmitter: EventEmitter;
+
+  /**
+   * @description
+   * Created socket instance
+   */
+  private socket: any;
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getEventEmitter
+   * @private
+   *
+   * @description
+   * Get request event emitter
+   */
+  getEventEmitter(): EventEmitter {
+    return this.eventEmitter;
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#getIncomingMessage
+   * @private
+   *
+   * @description
+   * Get IncomingMessage object
+   */
+  getIncomingMessage(): IncomingMessage {
+    return this.request;
+  }
+
+  getResolvedRoute(): IResolvedRoute {
+    return this.resolvedRoute;
+  }
+
+  getId(): string {
+    return this.id;
+  }
+
+  getBody(): Array<Buffer> {
+    return this.data;
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#destroy
+   * @private
+   * @description
+   * Destroy all references to free memory
+   */
+  destroy() {
+    this.eventEmitter.emit("destroy");
+    this.eventEmitter.removeAllListeners();
+    this.socket = null;
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#process
+   * @private
+   * @description
+   * Process request logic
+   */
+  async process(): Promise<SocketResolver> {
+    // set request reflection
+    const reflectionInjector = Injector.createAndResolveChild(this.injector, BaseRequest, [
+      {provide: "data", useValue: this.data},
+      {provide: "request", useValue: this.request},
+      {provide: "UUID", useValue: this.id},
+      {provide: "resolvedRoute", useValue: this.resolvedRoute}
+    ]);
+
+    this.socket = reflectionInjector.get(this.socketProvider.provide);
+
+    await this.processSocketFunction("verify");
+    return this;
+  }
+
+  async openSocket(ws: WebSocket): Promise<any> {
+
+  }
+
+  private async processSocketFunction(functionName: string) {
+    if (!isFunction(this.socket[functionName])) {
+      this.logger.debug("Tried to call socket function but not available", {
+        functionName
+      });
+      return;
+    }
+
+    const func: Function = this.socket[functionName].bind(this.socket);
+    const args = this.getAnnotatedArguments(this.socketProvider, functionName);
+
+    return await func.apply(this.socket, args);
+  }
+
+  private getAnnotatedArguments(provider: IProvider, functionName: string): Array<any> {
+    const params: Array<IParam> = Metadata
+      .getMetadata(provider.provide.prototype, FUNCTION_PARAMS)
+      .filter((param: IParam) => param.key === functionName);
+
+    return params
+      .sort((p1, p2) => p1.paramIndex - p2.paramIndex)
+      .map((param: IParam) => {
+        switch (param.type) {
+          case "Param":
+            if (isPresent(this.resolvedRoute.params) && this.resolvedRoute.params.hasOwnProperty(param.value)) {
+              return this.resolvedRoute.params[param.value];
+            } else {
+              return null;
+            }
+          case "Inject":
+            return this.injector.get(param.value);
+        }
+      });
+  }
+
+  /**
+   * @since 1.0.0
+   * @function
+   * @name Request#benchmark
+   * @private
+   * @description
+   * Print benchmark
+   */
+  private benchmark(message: string, start: number) {
+    this.logger.benchmark(`${message}: ${(Date.now() - start)}ms`, {
+      method: getMethodName(this.resolvedRoute.method),
+      route: this.resolvedRoute.route,
+      url: this.request.url
+    });
+  }
+}

--- a/src/server/socket-resolver.ts
+++ b/src/server/socket-resolver.ts
@@ -145,6 +145,10 @@ export class SocketResolver {
    * Destroy all references to free memory
    */
   destroy() {
+    if (isPresent(this.socket) && isFunction(this.socket.afterClose)) {
+      this.socket.afterClose();
+    }
+
     this.eventEmitter.emit("destroy");
     this.eventEmitter.removeAllListeners();
     this.socket = null;

--- a/src/server/socket.ts
+++ b/src/server/socket.ts
@@ -19,25 +19,81 @@ export interface IWebSocketResult {
   finished: () => void;
 }
 
+/**
+ * @since 2.0.0
+ * @class
+ * @constructor
+ * @name Socket
+ *
+ * @description
+ * Basic API for accessing a WebSocket in order to get state information, send data, or close the socket.
+ */
 export class Socket {
 
+  /**
+   * @since 2.0.0
+   * @param {WebSocket} ws Underlying WebSocket to wrap
+   *
+   * @description
+   * Creates a new API wrapping the given raw WebSocket
+   */
   constructor(private readonly ws: WebSocket) {
   }
 
+  /**
+   * @since 2.0.0
+   * @function
+   * @name Socket#getReadyState
+   * @return {number} Socket readyState
+   *
+   * @description
+   * Get the underlying WebSocket's readyState (see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket#Ready_state_constants)
+   */
   getReadyState(): number {
     return this.ws.readyState;
   }
 
+  /**
+   * @since 2.0.0
+   * @function
+   * @name Socket#close
+   * @param {number} status Status code to send as close reason
+   * @param {string} data Data to send as close reason
+   *
+   * @description
+   * Closes the underlying WebSocket
+   */
   close(status?: number, data?: string): void {
     this.ws.close(status, data);
   }
 
+  /**
+   * @since 2.0.0
+   * @function
+   * @name Socket#send
+   * @param data Data to send to the client
+   * @param {{mask?: boolean; binary?: boolean}|(err: Error) => void} options Either send options or the error callback
+   * @param {(err: Error) => void} cb (only if second parameter are options) error callback
+   */
   send(data: any, options?: { mask?: boolean; binary?: boolean } | ((err: Error) => void), cb?: (err: Error) => void): void {
     this.ws.send(data, options as any, cb);
   }
 
 }
 
+/**
+ * @since 2.0.0
+ * @function
+ * @name fireWebSocket
+ * @param {Array<IModule>} modules Bootstrapped modules
+ * @param {"http".IncomingMessage} request Incoming HTTP request
+ * @return {Promise<IWebSocketResult>} Promise which will resolve once the socket has been verified or reject on failure
+ *
+ * @description
+ * This method will trigger a WebSocket resolution and will try to find a matching {@link WebSocket} registered in the system.
+ * Typically you do not use this method directly but it is called automatically by the framework. For testing best
+ * refer to {@link FakeServerApi#createSocket}.
+ */
 export function fireWebSocket(modules: Array<IModule>, request: IncomingMessage): Promise<IWebSocketResult> {
   let rootInjector: Injector = getModule(modules).injector;
   let logger: Logger = rootInjector.get(Logger);

--- a/src/server/socket.ts
+++ b/src/server/socket.ts
@@ -71,34 +71,3 @@ export function fireWebSocket(modules: Array<IModule>, request: IncomingMessage)
       };
     });
 }
-
-/**
- * @since 1.1.0
- * @function
- * @name verifyWssClient
- * @return {boolean}
- * @private
- */
-export function verifyWssClient(modules: Array<IModule>, request: IncomingMessage, cb): boolean {
-  let rootInjector: Injector = getModule(modules).injector;
-  let logger: Logger = rootInjector.get(Logger);
-  /**
-   * Create HttpRequestResolver injector
-   */
-  let routeResolverInjector = Injector.createAndResolveChild(
-    rootInjector,
-    SocketRequestResolver,
-    [
-      {provide: "url", useValue: parse(request.url, true)},
-      {provide: "UUID", useValue: uuid()},
-      {provide: "data", useValue: []},
-      {provide: "contentType", useValue: "text/html"},
-      {provide: "statusCode", useValue: Status.OK},
-      {provide: "request", useValue: request},
-      {provide: "modules", useValue: modules},
-      EventEmitter
-    ]
-  );
-
-  return false;
-}

--- a/src/server/socket.ts
+++ b/src/server/socket.ts
@@ -1,8 +1,71 @@
 import {IncomingMessage} from "http";
 import {IModule} from "../interfaces/imodule";
+import {Logger} from "../logger/logger";
+import {SocketRequestResolver} from "./request-resolver";
+import {isFalsy, isObject, uuid} from "../core";
+import {Injector} from "../injector/injector";
+import {Status} from "./status-code";
+import {getModule} from "./bootstrap";
+import {parse} from "url";
+import {EventEmitter} from "events";
+import {HttpError} from "../error";
 
-export function fireWebSocket() {
-  // todo
+export interface IWebSocketResult {
+  uuid: string;
+  error?: any;
+  open?: () => void;
+  finished: () => void;
+}
+
+export function fireWebSocket(modules: Array<IModule>, request: IncomingMessage): Promise<IWebSocketResult> {
+  let rootInjector: Injector = getModule(modules).injector;
+  let logger: Logger = rootInjector.get(Logger);
+
+  const requestUuid = uuid();
+
+  /**
+   * Create SocketRequestResolver injector
+   */
+  let socketResolverInjector = Injector.createAndResolveChild(
+    rootInjector,
+    SocketRequestResolver,
+    [
+      {provide: "url", useValue: parse(request.url, true)},
+      {provide: "UUID", useValue: requestUuid},
+      {provide: "data", useValue: []},
+      {provide: "request", useValue: request},
+      {provide: "modules", useValue: modules},
+      EventEmitter
+    ]
+  );
+
+  const socketResolver: SocketRequestResolver = socketResolverInjector.get(SocketRequestResolver);
+  return socketResolver
+    .process()
+    .then((socket) => {
+      if (isFalsy(socket) || !isObject(socket)) {
+        throw new HttpError(Status.Internal_Server_Error, "Could not resolve socket");
+      } else {
+        return {
+          uuid: requestUuid,
+          open: () => {
+            logger.info("Resuming request", {uuid: requestUuid});
+          },
+          finished: () => {
+            socketResolverInjector.destroy();
+          }
+        };
+      }
+    })
+    .catch((error) => {
+      return {
+        uuid: requestUuid,
+        error: error,
+        finished: () => {
+          socketResolverInjector.destroy();
+        }
+      };
+    });
 }
 
 /**
@@ -12,6 +75,26 @@ export function fireWebSocket() {
  * @return {boolean}
  * @private
  */
-export function verifyWssClient(modules: Array<IModule>, req: IncomingMessage): boolean {
+export function verifyWssClient(modules: Array<IModule>, request: IncomingMessage, cb): boolean {
+  let rootInjector: Injector = getModule(modules).injector;
+  let logger: Logger = rootInjector.get(Logger);
+  /**
+   * Create HttpRequestResolver injector
+   */
+  let routeResolverInjector = Injector.createAndResolveChild(
+    rootInjector,
+    SocketRequestResolver,
+    [
+      {provide: "url", useValue: parse(request.url, true)},
+      {provide: "UUID", useValue: uuid()},
+      {provide: "data", useValue: []},
+      {provide: "contentType", useValue: "text/html"},
+      {provide: "statusCode", useValue: Status.OK},
+      {provide: "request", useValue: request},
+      {provide: "modules", useValue: modules},
+      EventEmitter
+    ]
+  );
+
   return false;
 }

--- a/src/server/socket.ts
+++ b/src/server/socket.ts
@@ -1,0 +1,17 @@
+import {IncomingMessage} from "http";
+import {IModule} from "../interfaces/imodule";
+
+export function fireWebSocket() {
+  // todo
+}
+
+/**
+ * @since 1.1.0
+ * @function
+ * @name verifyWssClient
+ * @return {boolean}
+ * @private
+ */
+export function verifyWssClient(modules: Array<IModule>, req: IncomingMessage): boolean {
+  return false;
+}

--- a/src/server/socket.ts
+++ b/src/server/socket.ts
@@ -42,9 +42,12 @@ export function fireWebSocket(modules: Array<IModule>, request: IncomingMessage)
   );
 
   const socketResolver: SocketRequestResolver = socketResolverInjector.get(SocketRequestResolver);
+  logger.debug("Resolved SocketRequestResolver - starting processing", {request});
+
   return socketResolver
     .process()
     .then((socket: SocketResolver) => {
+      logger.debug("socketResolver.then result:", {socket});
       if (!isPresent(socket)) {
         throw new HttpError(Status.Internal_Server_Error, "Could not resolve socket");
       } else {
@@ -62,6 +65,7 @@ export function fireWebSocket(modules: Array<IModule>, request: IncomingMessage)
       }
     })
     .catch((error) => {
+      logger.error("fireWebSocket: Failed to create socket", {error});
       return {
         uuid: requestUuid,
         error: error,

--- a/src/server/socket.ts
+++ b/src/server/socket.ts
@@ -2,18 +2,20 @@ import {IncomingMessage} from "http";
 import {IModule} from "../interfaces/imodule";
 import {Logger} from "../logger/logger";
 import {SocketRequestResolver} from "./request-resolver";
-import {isFalsy, isObject, uuid} from "../core";
+import {isPresent, uuid} from "../core";
 import {Injector} from "../injector/injector";
 import {Status} from "./status-code";
 import {getModule} from "./bootstrap";
 import {parse} from "url";
 import {EventEmitter} from "events";
 import {HttpError} from "../error";
+import {SocketResolver} from "./socket-resolver";
+import * as WebSocket from "ws";
 
 export interface IWebSocketResult {
   uuid: string;
   error?: any;
-  open?: () => void;
+  open?: (ws: WebSocket) => Promise<any>;
   finished: () => void;
 }
 
@@ -42,16 +44,18 @@ export function fireWebSocket(modules: Array<IModule>, request: IncomingMessage)
   const socketResolver: SocketRequestResolver = socketResolverInjector.get(SocketRequestResolver);
   return socketResolver
     .process()
-    .then((socket) => {
-      if (isFalsy(socket) || !isObject(socket)) {
+    .then((socket: SocketResolver) => {
+      if (!isPresent(socket)) {
         throw new HttpError(Status.Internal_Server_Error, "Could not resolve socket");
       } else {
         return {
           uuid: requestUuid,
-          open: () => {
+          open: (ws: WebSocket) => {
             logger.info("Resuming request", {uuid: requestUuid});
+            return socket.openSocket(ws);
           },
           finished: () => {
+            socket.destroy();
             socketResolverInjector.destroy();
           }
         };

--- a/src/tests/fake-request.ts
+++ b/src/tests/fake-request.ts
@@ -1,19 +1,12 @@
-import {use, assert} from "chai";
+import {assert, use} from "chai";
 import * as sinonChai from "sinon-chai";
-import {Methods, Router} from "../router/router";
+import {Methods, Router} from "../router";
 import {Logger, LogLevels} from "../logger/logger";
-import {Module} from "../decorators/module";
-import {Controller} from "../decorators/controller";
-import {Action, Before} from "../decorators/action";
-import {IAfterConstruct} from "../interfaces/iprovider";
-import {Inject} from "../decorators/inject";
-import {fakeHttpServer, FakeServerApi, FakeResponseApi} from "../server/mocks";
-import {Chain} from "../decorators/chain";
-import {Request} from "../server/controller-resolver";
-import {Status} from "../server/status-code";
+import {Action, Before, Chain, Controller, ErrorMessage, Inject, Module} from "../decorators";
+import {IAfterConstruct} from "../interfaces";
+import {fakeHttpServer, FakeResponseApi, FakeServerApi, Request, Status} from "../server";
 import {isEqual} from "../core";
 import {HttpError} from "../error";
-import {ErrorMessage} from "../decorators/error";
 
 // use chai spies
 use(sinonChai);
@@ -200,7 +193,6 @@ describe("fakeHttpServer", () => {
       done();
     }).catch(done);
   });
-
 
 
 });

--- a/src/tests/fake-socket.ts
+++ b/src/tests/fake-socket.ts
@@ -1,0 +1,77 @@
+import {assert, use} from "chai";
+import * as sinonChai from "sinon-chai";
+import {Methods, Router} from "../router/router";
+import {Logger, LogLevels} from "../logger/logger";
+import {Module} from "../decorators/module";
+import {IAfterConstruct} from "../interfaces/iprovider";
+import {Inject} from "../decorators/inject";
+import {fakeHttpServer, FakeServerApi} from "../server/mocks";
+import {WebSocket} from "../decorators/websocket";
+
+// use chai spies
+use(sinonChai);
+
+describe("fakeHttpServer with Sockets", () => {
+
+  let server: FakeServerApi;
+
+  beforeEach(() => {
+
+    @WebSocket({
+      name: "core"
+    })
+    class MySocket {
+    }
+
+    @Module({
+      name: "root",
+      providers: [Logger, Router],
+      sockets: [MySocket]
+    })
+    class MyModule implements IAfterConstruct {
+      afterConstruct(): void {
+        this.router.addRules([
+          {
+            methods: [Methods.GET, Methods.OPTIONS, Methods.CONNECT, Methods.DELETE, Methods.HEAD, Methods.TRACE],
+            url: "/",
+            route: "core/index"
+          },
+          {
+            methods: [Methods.POST, Methods.PUT, Methods.PATCH],
+            url: "/ajax/call",
+            route: "core/call"
+          },
+          {
+            methods: [Methods.GET],
+            url: "/redirect",
+            route: "core/redirect"
+          },
+          {
+            methods: [Methods.GET],
+            url: "/fire-error",
+            route: "core/fire"
+          }
+        ]);
+        this.router.setError("core/error");
+        this.logger.printToConsole();
+        this.logger.enable();
+        this.logger.setDebugLevel(LogLevels.BENCHMARK);
+      }
+
+      @Inject(Logger)
+      private logger: Logger;
+
+      @Inject(Router)
+      private router: Router;
+    }
+
+    server = fakeHttpServer(MyModule);
+  });
+
+
+  it("Should create a socket", () => {
+    const ws = server.openSocket("/echo");
+    assert.isDefined(ws);
+  });
+
+});

--- a/src/tests/request-controller.spec.ts
+++ b/src/tests/request-controller.spec.ts
@@ -1,14 +1,15 @@
 import {Methods} from "../router/router";
 import {Injector} from "../injector/injector";
 import {IResolvedRoute} from "../interfaces/iroute";
-import {Request, ControllerResolver} from "../server/controller-resolver";
+import {ControllerResolver} from "../server/controller-resolver";
+import {Request} from "../server/request";
 import {assert, use} from "chai";
 import * as sinonChai from "sinon-chai";
-import {spy, stub, assert as assertSpy} from "sinon";
+import {assert as assertSpy, spy, stub} from "sinon";
 import {EventEmitter} from "events";
 import {isEqual, uuid} from "../core";
 import {Logger} from "../logger/logger";
-import {Action, Before, After, BeforeEach, AfterEach} from "../decorators/action";
+import {Action, After, AfterEach, Before, BeforeEach} from "../decorators/action";
 import {Metadata} from "../injector/metadata";
 import {IAction} from "../interfaces/iaction";
 import {Produces} from "../decorators/produces";
@@ -97,14 +98,6 @@ describe("ControllerResolver", () => {
     assert.isTrue(isEqual(controllerResolver.getServerResponse(), response));
   });
 
-  it("ControllerResolver.getBody", () => {
-    assert.isTrue(isEqual(controllerResolver.getBody(), Buffer.concat(data)));
-  });
-
-  it("ControllerResolver.getUUID", () => {
-    assert.isTrue(isEqual(controllerResolver.getUUID(), id));
-  });
-
   it("ControllerResolver.process", () => {
     let aSpy = stub(controllerResolver, "processController");
     aSpy.returnsArg(0);
@@ -116,9 +109,9 @@ describe("ControllerResolver", () => {
     class B {
       @Action("index")
       index() {
-
       }
     }
+
     let provider = Metadata.verifyProvider(B);
     assert.isTrue(controllerResolver.hasMappedAction(provider, "index"));
     assert.isFalse(controllerResolver.hasMappedAction(provider, "nomappedAction"));
@@ -136,12 +129,14 @@ describe("ControllerResolver", () => {
 
       }
     }
+
     class B extends A {
       @Action("index")
       actionIndex() {
 
       }
     }
+
     let aProvider = Metadata.verifyProvider(A);
     let bProvider = Metadata.verifyProvider(B);
     assert.isFalse(controllerResolver.hasMappedAction(aProvider, "index"));
@@ -184,6 +179,7 @@ describe("ControllerResolver", () => {
 
       }
     }
+
     class B extends A {
       @Produces("application/json")
       @Action("index")
@@ -191,6 +187,7 @@ describe("ControllerResolver", () => {
 
       }
     }
+
     let aProvider = Metadata.verifyProvider(A);
     let bProvider = Metadata.verifyProvider(B);
 
@@ -223,6 +220,7 @@ describe("ControllerResolver", () => {
 
       }
     }
+
     class B extends A {
 
       constructor(private test: Logger) {
@@ -235,6 +233,7 @@ describe("ControllerResolver", () => {
 
       }
     }
+
     let bProvider = Metadata.verifyProvider(B);
     let action: IAction = controllerResolver.getMappedAction(bProvider, "index");
     let arg = controllerResolver.getMappedActionArguments(bProvider, action);
@@ -242,16 +241,16 @@ describe("ControllerResolver", () => {
     assert.deepEqual(arg, [
         {
           Class: B,
-          type: 'Inject',
-          key: 'actionIndex',
+          type: "Inject",
+          key: "actionIndex",
           value: Logger,
           paramIndex: 1
         },
         {
           Class: B,
           type: "Param",
-          key: 'actionIndex',
-          value: 'a',
+          key: "actionIndex",
+          value: "a",
           paramIndex: 0
         }
       ]
@@ -262,6 +261,7 @@ describe("ControllerResolver", () => {
 
   it("ControllerResolver.processAction", () => {
     let aSpy = spy(eventEmitter, "emit");
+
     @Controller({
       name: "root"
     })
@@ -309,11 +309,11 @@ describe("ControllerResolver", () => {
     @Filter(10)
     class AFilter implements IFilter {
 
-      before(data: string): string|Buffer|Promise<string|Buffer> {
+      before(data: string): string | Buffer | Promise<string | Buffer> {
         return "aFilter <- " + data;
       }
 
-      after(data: string): string|Buffer|Promise<string|Buffer> {
+      after(data: string): string | Buffer | Promise<string | Buffer> {
         return "aFilter <- " + data;
       }
 
@@ -322,11 +322,11 @@ describe("ControllerResolver", () => {
     @Filter(20)
     class BFilter implements IFilter {
 
-      before(data: string): string|Buffer|Promise<string|Buffer> {
+      before(data: string): string | Buffer | Promise<string | Buffer> {
         return "bFilter <- " + data;
       }
 
-      after(data: string): string|Buffer|Promise<string|Buffer> {
+      after(data: string): string | Buffer | Promise<string | Buffer> {
         return "bFilter <- " + data;
       }
 
@@ -369,7 +369,6 @@ describe("ControllerResolver", () => {
   });
 
 
-
   it("ControllerResolver.processController no action chain", (done) => {
     @Controller({
       name: "root"
@@ -384,6 +383,7 @@ describe("ControllerResolver", () => {
         };
       }
     }
+
     let aProvider = Metadata.verifyProvider(A);
     // process controller
     let result = controllerResolver.processController(new Injector(), aProvider, "index");
@@ -459,11 +459,11 @@ describe("ControllerResolver", () => {
     @Filter(10)
     class AFilter implements IFilter {
 
-      before(data: string): string|Buffer|Promise<string|Buffer> {
+      before(data: string): string | Buffer | Promise<string | Buffer> {
         return "aFilter <- " + data;
       }
 
-      after(data: string): string|Buffer|Promise<string|Buffer> {
+      after(data: string): string | Buffer | Promise<string | Buffer> {
         return "aFilter <- " + data;
       }
 
@@ -472,11 +472,11 @@ describe("ControllerResolver", () => {
     @Filter(20)
     class BFilter implements IFilter {
 
-      before(data: string): string|Buffer|Promise<string|Buffer> {
+      before(data: string): string | Buffer | Promise<string | Buffer> {
         return "bFilter <- " + data;
       }
 
-      after(data: string): string|Buffer|Promise<string|Buffer> {
+      after(data: string): string | Buffer | Promise<string | Buffer> {
         return "bFilter <- " + data;
       }
 
@@ -533,20 +533,16 @@ describe("ControllerResolver", () => {
   });
 
 
-
-
-
-
   it("ControllerResolver.processController with stopChain", (done) => {
 
     @Filter(10)
     class AFilter implements IFilter {
 
-      before(data: string): string|Buffer|Promise<string|Buffer> {
+      before(data: string): string | Buffer | Promise<string | Buffer> {
         return "aFilter <- " + data;
       }
 
-      after(data: string): string|Buffer|Promise<string|Buffer> {
+      after(data: string): string | Buffer | Promise<string | Buffer> {
         return "aFilter <- " + data;
       }
 
@@ -555,11 +551,11 @@ describe("ControllerResolver", () => {
     @Filter(20)
     class BFilter implements IFilter {
 
-      before(data: string): string|Buffer|Promise<string|Buffer> {
+      before(data: string): string | Buffer | Promise<string | Buffer> {
         return "bFilter <- " + data;
       }
 
-      after(data: string): string|Buffer|Promise<string|Buffer> {
+      after(data: string): string | Buffer | Promise<string | Buffer> {
         return "bFilter <- " + data;
       }
 
@@ -621,7 +617,6 @@ describe("ControllerResolver", () => {
   });
 
 
-
   it("ControllerResolver.processController with stopChain in Filter 1", (done) => {
 
     @Filter(10)
@@ -630,12 +625,12 @@ describe("ControllerResolver", () => {
       @Inject(Request)
       private request: Request;
 
-      before(data: string): string|Buffer|Promise<string|Buffer> {
+      before(data: string): string | Buffer | Promise<string | Buffer> {
         this.request.stopChain();
         return "aFilter <- " + data;
       }
 
-      after(data: string): string|Buffer|Promise<string|Buffer> {
+      after(data: string): string | Buffer | Promise<string | Buffer> {
         return "aFilter <- " + data;
       }
 
@@ -644,11 +639,11 @@ describe("ControllerResolver", () => {
     @Filter(20)
     class BFilter implements IFilter {
 
-      before(data: string): string|Buffer|Promise<string|Buffer> {
+      before(data: string): string | Buffer | Promise<string | Buffer> {
         return "bFilter <- " + data;
       }
 
-      after(data: string): string|Buffer|Promise<string|Buffer> {
+      after(data: string): string | Buffer | Promise<string | Buffer> {
         return "bFilter <- " + data;
       }
 
@@ -709,8 +704,6 @@ describe("ControllerResolver", () => {
   });
 
 
-
-
   it("ControllerResolver.processController with stopChain in Filter 2", (done) => {
 
     @Filter(10)
@@ -719,12 +712,12 @@ describe("ControllerResolver", () => {
       @Inject(Request)
       private request: Request;
 
-      before(data: string): string|Buffer|Promise<string|Buffer> {
+      before(data: string): string | Buffer | Promise<string | Buffer> {
         this.request.stopChain();
         return "aFilter <- " + data;
       }
 
-      after(data: string): string|Buffer|Promise<string|Buffer> {
+      after(data: string): string | Buffer | Promise<string | Buffer> {
         return "aFilter <- " + data;
       }
 
@@ -737,12 +730,12 @@ describe("ControllerResolver", () => {
       private request: Request;
 
 
-      before(data: string): string|Buffer|Promise<string|Buffer> {
+      before(data: string): string | Buffer | Promise<string | Buffer> {
         this.request.stopChain();
         return "bFilter <- " + data;
       }
 
-      after(data: string): string|Buffer|Promise<string|Buffer> {
+      after(data: string): string | Buffer | Promise<string | Buffer> {
         return "bFilter <- " + data;
       }
 
@@ -785,6 +778,7 @@ describe("ControllerResolver", () => {
       }
 
     }
+
     // process controller
 
     let result = fakeControllerActionCall(

--- a/src/tests/request-resolver.spec.ts
+++ b/src/tests/request-resolver.spec.ts
@@ -6,7 +6,7 @@ import {Methods, Router} from "../router/router";
 import {uuid} from "../core";
 import {EventEmitter} from "events";
 import {Injector} from "../injector/injector";
-import {RequestResolver, RenderType} from "../server/request-resolver";
+import {HttpRequestResolver, RenderType} from "../server/request-resolver";
 import {parse} from "url";
 import {Logger} from "../logger/logger";
 import {IResolvedModule, IModule} from "../interfaces/imodule";
@@ -22,9 +22,9 @@ import {setTimeout} from "timers";
 // use chai spies
 use(sinonChai);
 
-describe("RequestResolver", () => {
+describe("HttpRequestResolver", () => {
   let resolvedRoute: IResolvedRoute;
-  let routeResolver: RequestResolver;
+  let routeResolver: HttpRequestResolver;
   let request, response, data, id = uuid();
 
   beforeEach(() => {
@@ -55,7 +55,7 @@ describe("RequestResolver", () => {
     data = [new Buffer(1), new Buffer(1)];
     let injector = Injector.createAndResolveChild(
       new Injector(),
-      RequestResolver,
+      HttpRequestResolver,
       [
         Logger,
         Router,
@@ -70,7 +70,7 @@ describe("RequestResolver", () => {
         EventEmitter
       ]
     );
-    routeResolver = injector.get(RequestResolver);
+    routeResolver = injector.get(HttpRequestResolver);
   });
 
 
@@ -130,7 +130,7 @@ describe("RequestResolver", () => {
     };
 
     let provider = Metadata.verifyProvider(MyController);
-    let controllerProvider: IProvider = RequestResolver.getControllerProvider(module);
+    let controllerProvider: IProvider = HttpRequestResolver.getControllerProvider(module);
     assert.deepEqual(provider, controllerProvider);
   });
 
@@ -164,7 +164,7 @@ describe("RequestResolver", () => {
     };
 
     assert.throws(() => {
-      RequestResolver.getControllerProvider(module);
+      HttpRequestResolver.getControllerProvider(module);
     }, "You must define controller within current route: core/index");
   });
 
@@ -249,7 +249,7 @@ describe("RequestResolver", () => {
     let modules: Array<IModule> = createModule(MyModule);
     let injector = Injector.createAndResolveChild(
       getModule(modules).injector,
-      RequestResolver,
+      HttpRequestResolver,
       [
         {provide: "url", useValue: parse("/", true)},
         {provide: "UUID", useValue: id},
@@ -262,7 +262,7 @@ describe("RequestResolver", () => {
         EventEmitter
       ]
     );
-    let myRouteResolver = injector.get(RequestResolver);
+    let myRouteResolver = injector.get(HttpRequestResolver);
 
 
     let aSpy = spy(myRouteResolver, "render");
@@ -316,7 +316,7 @@ describe("RequestResolver", () => {
     let modules: Array<IModule> = createModule(MyModule);
     let injector = Injector.createAndResolveChild(
       getModule(modules).injector,
-      RequestResolver,
+      HttpRequestResolver,
       [
         {provide: "url", useValue: parse("/", true)},
         {provide: "UUID", useValue: id},
@@ -329,7 +329,7 @@ describe("RequestResolver", () => {
         EventEmitter
       ]
     );
-    let myRouteResolver = injector.get(RequestResolver);
+    let myRouteResolver = injector.get(HttpRequestResolver);
 
     let a = [Buffer.from("a"), Buffer.from("b"), Buffer.from("c")];
 

--- a/src/tests/request-resolver.spec.ts
+++ b/src/tests/request-resolver.spec.ts
@@ -123,7 +123,7 @@ describe("HttpRequestResolver", () => {
     let modules: Array<IModule> = createModule(MyModule);
     let module: IResolvedModule = {
       module: getModule(modules),
-      controller: "core",
+      endpoint: "core",
       action: "index",
       resolvedRoute,
       data
@@ -157,7 +157,7 @@ describe("HttpRequestResolver", () => {
     let modules: Array<IModule> = createModule(MyModule);
     let module: IResolvedModule = {
       module: getModule(modules),
-      controller: "test",
+      endpoint: "test",
       action: "index",
       resolvedRoute,
       data
@@ -195,7 +195,7 @@ describe("HttpRequestResolver", () => {
     let modules: Array<IModule> = createModule(MyModule);
     let module: IResolvedModule = {
       module: getModule(modules),
-      controller: "core",
+      endpoint: "core",
       action: "index",
       resolvedRoute,
       data
@@ -348,7 +348,7 @@ describe("HttpRequestResolver", () => {
       .then(resolved => {
         let module: IResolvedModule = {
           module: getModule(modules, "root"),
-          controller: "core",
+          endpoint: "core",
           action: "index",
           resolvedRoute: {
             method: Methods.POST,

--- a/src/tests/request.spec.ts
+++ b/src/tests/request.spec.ts
@@ -1,65 +1,202 @@
 import {Methods} from "../router/router";
 import {Injector} from "../injector/injector";
 import {IResolvedRoute} from "../interfaces/iroute";
-import {Request, ControllerResolver} from "../server/controller-resolver";
+import {ControllerResolver} from "../server/controller-resolver";
 import {assert, expect, use} from "chai";
 import * as sinonChai from "sinon-chai";
-import {spy, stub, assert as assertSpy} from "sinon";
+import {assert as assertSpy, spy, stub} from "sinon";
 import {EventEmitter} from "events";
-import {IConnection} from "../interfaces/iconnection";
-import {isEqual} from "../core";
+import {isEqual, uuid} from "../core";
+import {BaseRequest, Request} from "../server/request";
 
 // use chai spies
 use(sinonChai);
 
-describe("Request", () => {
-
-
-  let resolvedRoute: IResolvedRoute;
-  let eventEmitter;
-
-  let incommingMessage = Object.create({
+describe("BaseRequest", () => {
+  const resolvedRoute: IResolvedRoute = {
+    method: Methods.GET,
+    params: {
+      a: 1,
+      b: 2
+    },
+    route: "core/index"
+  };
+  const incomingMessage = Object.create({
+    uuid: "1",
+    method: "GET",
+    url: "/",
+    httpVersion: "1.1",
+    httpVersionMajor: 1,
+    httpVersionMinor: 1,
+    connection: {
+      remoteAddress: "192.0.0.1",
+      remoteFamily: "",
+      remotePort: 9000,
+      localAddress: "192.0.0.1",
+      localPort: 9000
+    },
     headers: {}
   });
+  const data: Array<Buffer> = [Buffer.from(["a", "b", "c"])];
+  const UUID: string = uuid();
 
-  let controllerResolver;
+  let request: BaseRequest;
 
+  beforeEach(() => {
+    const injector = Injector.createAndResolve(BaseRequest, [
+      {provide: "resolvedRoute", useValue: resolvedRoute},
+      {provide: "request", useValue: incomingMessage},
+      {provide: "UUID", useValue: UUID},
+      {provide: "data", useValue: data}
+    ]);
+    request = injector.get(BaseRequest);
+  });
+
+  it("BaseRequest.constructor", () => {
+    assert.isTrue(request instanceof BaseRequest);
+  });
+
+  it("BaseRequest.getConnection", () => {
+    let conn = request.getConnection();
+    assert.deepEqual(conn, {
+      uuid: UUID,
+      method: "GET",
+      url: "/",
+      httpVersion: "1.1",
+      httpVersionMajor: 1,
+      httpVersionMinor: 1,
+      remoteAddress: "192.0.0.1",
+      remoteFamily: "",
+      remotePort: 9000,
+      localAddress: "192.0.0.1",
+      localPort: 9000
+    });
+  });
+
+  it("BaseRequest.getCookies", () => {
+    let aSpy = stub(request, "getRequestHeader");
+    aSpy.returns("__id=d6ad83ce4a84516bf7d438504e81b139a1483565272; __id2=1;");
+    let requestCookies = request.getCookies();
+    let cookies = {
+      __id: "d6ad83ce4a84516bf7d438504e81b139a1483565272",
+      __id2: "1"
+    };
+    assertSpy.called(aSpy);
+    assert.isTrue(isEqual(requestCookies, cookies));
+  });
+
+  it("BaseRequest.getCookie", () => {
+    let aSpy = stub(request, "getCookies");
+    aSpy.returns({
+      __id: "d6ad83ce4a84516bf7d438504e81b139a1483565272",
+      __id2: "1"
+    });
+    let id = request.getCookie("__id");
+    assertSpy.called(aSpy);
+    assert.equal(id, "d6ad83ce4a84516bf7d438504e81b139a1483565272");
+  });
+
+  it("BaseRequest.getCookies null", () => {
+    let aSpy = stub(request, "getRequestHeader");
+    aSpy.returns(null);
+    let requestCookies = request.getCookies();
+    let cookies = {};
+    assertSpy.called(aSpy);
+    assert.isTrue(isEqual(requestCookies, cookies));
+  });
+
+  it("BaseRequest.getRequestHeaders", () => {
+    let rHeaders = request.getRequestHeaders();
+    assert.isTrue(isEqual(rHeaders, {}));
+  });
+
+  it("BaseRequest.getRequestHeader", () => {
+    let aSpy = stub(request, "getRequestHeaders");
+    let headers = {accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"};
+    aSpy.returns(headers);
+    let rHeaders = request.getRequestHeader("Accept");
+    assertSpy.called(aSpy);
+    assert.isTrue(isEqual(rHeaders, headers.accept));
+  });
+
+  it("BaseRequest.getParams", () => {
+    assert.isTrue(isEqual(request.getParams(), resolvedRoute.params));
+  });
+
+  it("BaseRequest.getParam", () => {
+    assert.isTrue(isEqual(request.getParam("a"), 1));
+  });
+
+  it("BaseRequest.getMethod", () => {
+    assert.isTrue(isEqual(request.getMethod(), Methods.GET));
+  });
+
+  it("BaseRequest.getRoute", () => {
+    assert.isTrue(isEqual(request.getRoute(), "core/index"));
+  });
+
+  it("BaseRequest.getBody", () => {
+    const body = request.getBody();
+    assert.isTrue(isEqual(body, Buffer.concat(data)));
+  });
+});
+
+describe("Request", () => {
+  const resolvedRoute: IResolvedRoute = {
+    method: Methods.GET,
+    params: {
+      a: 1,
+      b: 2
+    },
+    route: "core/index"
+  };
+  const incomingMessage = Object.create({
+    headers: {}
+  });
+  const data = [Buffer.from(["a", "b", "c"])];
+  const UUID = 1;
+
+  let eventEmitter: EventEmitter;
+  let controllerResolver: ControllerResolver;
   let request: Request;
 
   beforeEach(() => {
     eventEmitter = new EventEmitter();
-    resolvedRoute = {
-      method: Methods.GET,
-      params: {
-        a: 1,
-        b: 2
-      },
-      route: "core/index"
-    };
+
     controllerResolver = Object.create({
       getEventEmitter: () => {
         return eventEmitter;
       },
       getRequestHeader: () => {
+        // dummy
       },
       getServerResponse: () => {
+        // dummy
       },
       getIncomingMessage: () => {
-        return incommingMessage;
+        return incomingMessage;
+      },
+      getResolvedRoute: () => {
+        return resolvedRoute;
+      },
+      getId: () => {
+        return UUID;
+      },
+      getRawData: () => {
+        return data;
       },
       setContentType: () => {
+        // dummy
       },
-      getBody: () => {
-      },
-      getUUID: () => "1",
       setStatusCode: () => {
+        // dummy
       },
       stopChain: () => {
+        // dummy
       }
     });
     let injector = Injector.createAndResolve(Request, [
-      {provide: "resolvedRoute", useValue: resolvedRoute},
-      {provide: ControllerResolver, useValue: controllerResolver}
+      {provide: "controllerResolver", useValue: controllerResolver}
     ]);
     request = injector.get(Request);
   });
@@ -72,11 +209,11 @@ describe("Request", () => {
     let eSpy = spy(controllerResolver, "getEventEmitter");
     let isCalled = false;
 
-    function destory() {
+    function destroy() {
       isCalled = true;
     }
 
-    request.onDestroy(destory);
+    request.onDestroy(destroy);
     assertSpy.called(eSpy);
 
     expect(EventEmitter.listenerCount(eventEmitter, "destroy")).to.be.eq(1);
@@ -84,118 +221,10 @@ describe("Request", () => {
     assert.isTrue(isCalled);
   });
 
-
-  it("Request.getConnection", () => {
-    let connection = {
-      uuid: "1",
-      method: "GET",
-      url: "/",
-      httpVersion: "1.1",
-      httpVersionMajor: 1,
-      httpVersionMinor: 1,
-      connection: {
-        remoteAddress: "192.0.0.1",
-        remoteFamily: "",
-        remotePort: 9000,
-        localAddress: "192.0.0.1",
-        localPort: 9000
-      }
-    };
-    let aSpy = stub(controllerResolver, "getIncomingMessage");
-    aSpy.returns(connection);
-    let bSpy = spy(controllerResolver, "getUUID");
-
-    let data = request.getConnection();
-
-    assertSpy.called(aSpy);
-    assertSpy.called(bSpy);
-
-    assert.isTrue(isEqual(data, {
-      uuid: "1",
-      method: "GET",
-      url: "/",
-      httpVersion: "1.1",
-      httpVersionMajor: 1,
-      httpVersionMinor: 1,
-      remoteAddress: "192.0.0.1",
-      remoteFamily: "",
-      remotePort: 9000,
-      localAddress: "192.0.0.1",
-      localPort: 9000
-    }));
-  });
-
-
-  it("Request.getCookies", () => {
-    let aSpy = stub(request, "getRequestHeader");
-    aSpy.returns("__id=d6ad83ce4a84516bf7d438504e81b139a1483565272; __id2=1;");
-    let data = request.getCookies();
-    let cookies = {
-      __id: "d6ad83ce4a84516bf7d438504e81b139a1483565272",
-      __id2: "1"
-    };
-    assertSpy.called(aSpy);
-    assert.isTrue(isEqual(data, cookies));
-  });
-
-  it("Request.getCookie", () => {
-    let aSpy = stub(request, "getCookies");
-    aSpy.returns({
-      __id: "d6ad83ce4a84516bf7d438504e81b139a1483565272",
-      __id2: "1"
-    });
-    let id = request.getCookie("__id");
-    assertSpy.called(aSpy);
-    assert.equal(id, "d6ad83ce4a84516bf7d438504e81b139a1483565272");
-  });
-
-  it("Request.getCookies null", () => {
-    let aSpy = stub(request, "getRequestHeader");
-    aSpy.returns(null);
-    let data = request.getCookies();
-    let cookies = {};
-    assertSpy.called(aSpy);
-    assert.isTrue(isEqual(data, cookies));
-  });
-
-  it("Request.setCookie", () => {
-    let key = "id";
-    let value = "d6ad83ce4a84516bf7d438504e81b139a1483565272";
-    let expires = new Date();
-    let domain = "sub.example.com";
-    let path = "/test";
-    let isHttpOnly = true;
-    let str = "id=d6ad83ce4a84516bf7d438504e81b139a1483565272; Expires=" + expires.toUTCString() + "; Path=sub.example.com; Domain=/test; HttpOnly";
-    let aSpy = stub(request, "setResponseHeader");
-    request.setCookie(key, value, expires, domain, path, isHttpOnly);
-    assertSpy.calledWith(aSpy, "Set-cookie", str);
-  });
-
-  it("Request.getRequestHeaders", () => {
-    let aSpy = stub(controllerResolver, "getIncomingMessage");
-    let headers = {
-      headers: {}
-    };
-    aSpy.returns(headers);
-    let rHeaders = request.getRequestHeaders();
-    assertSpy.called(aSpy);
-    assert.isTrue(isEqual(rHeaders, {}));
-  });
-
-
-  it("Request.getRequestHeader", () => {
-    let aSpy = stub(request, "getRequestHeaders");
-    let headers = {accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"};
-    aSpy.returns(headers);
-    let rHeaders = request.getRequestHeader("Accept");
-    assertSpy.called(aSpy);
-    assert.isTrue(isEqual(rHeaders, headers.accept));
-  });
-
-
   it("Request.setResponseHeader", () => {
     let api = {
       setHeader: (a, b) => {
+        // dummy
       }
     };
     let bSpy = stub(api, "setHeader");
@@ -210,29 +239,6 @@ describe("Request", () => {
     let aSpy = spy(eventEmitter, "emit");
     request.setContentType("application/javascript");
     assertSpy.calledWith(aSpy, "contentType", "application/javascript");
-  });
-
-
-  it("Request.getParams", () => {
-    assert.isTrue(isEqual(request.getParams(), resolvedRoute.params));
-  });
-
-  it("Request.getParam", () => {
-    assert.isTrue(isEqual(request.getParam("a"), 1));
-  });
-
-  it("Request.getMethod", () => {
-    assert.isTrue(isEqual(request.getMethod(), Methods.GET));
-  });
-
-  it("Request.getRoute", () => {
-    assert.isTrue(isEqual(request.getRoute(), "core/index"));
-  });
-
-  it("Request.getBody", () => {
-    let aSpy = stub(controllerResolver, "getBody");
-    request.getBody();
-    assertSpy.called(aSpy);
   });
 
   it("Request.setStatusCode", () => {


### PR DESCRIPTION
This PR adds support for WebSockets based on the [`ws`](http://websockets.github.io/ws/) library. The implementation leverages the same injection mechanism and possibilities that are available for regular request controllers (expect filter chains). It also provides a matching fake/mock implementation to use in unit tests.

- [x] configuration option to enable WebSocket support in general
- [x] provide unit tests to demonstrate functionality
- [x] add JSDoc documentation in TypeScript
- [ ] add example in demo application
- [ ] add detailed description to public documentation on [GitBooks](https://igorivanovic.gitbooks.io/typeix/content/)

closes #3 